### PR TITLE
Fixes the import error for cachetools (for version >= 2)

### DIFF
--- a/python_filmaffinity/__init__.py
+++ b/python_filmaffinity/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 import requests
 from functools import partial
-from cachetools import cached, hashkey
+from cachetools import __version__ as cachetools_version
+if int(cachetools_version.split('.')[0]) >= 2:
+    from cachetools import cached
+    from cachetools.keys import hashkey
+else:
+    from cachetools import cached, hashkey
 
 from .client import Client
 from .config import FIELDS_TYPE, cache


### PR DESCRIPTION
Due to recent changes with cachetools, this module no longer works, so this "pull request" solve the problem.