### PR TITLE
Enhances coverage and fixes failed tests

### DIFF
--- a/python_filmaffinity/pages/detail.py
+++ b/python_filmaffinity/pages/detail.py
@@ -7,24 +7,27 @@ class DetailPage(Page):
 
     def get_title(self):
         """Get the title."""
+        name = None
         name_cell = self.soup.find("span", {"itemprop": 'name'})
-        if not name_cell:
-            return None
-        return name_cell.get_text()
+        if name_cell:
+            name = name_cell.get_text()
+        return name
 
     def get_year(self):
         """Get the year."""
+        year = None
         year_cell = self.soup.find("dd", {"itemprop": 'datePublished'})
-        if not year_cell:
-            return None
-        return year_cell.get_text()
+        if year_cell:
+            year = year_cell.get_text()
+        return year
 
     def get_description(self):
         """Get the description."""
+        description = None
         description_cell = self.soup.find("dd", {"itemprop": 'description'})
-        if not description_cell:
-            return None
-        return description_cell.get_text()
+        if description_cell:
+            description = description_cell.get_text()
+        return description
 
     def get_rating(self):
         """Get the rating."""
@@ -76,25 +79,27 @@ class DetailPage(Page):
 
     def get_duration(self):
         """Get Duration."""
+        duration = ''
         dc = self.soup.find("dd", {"itemprop": 'duration'})
-        if not dc:
-            return None
-        return dc.get_text()
+        if dc:
+            duration = dc.get_text()
+        return duration
 
     def get_country(self):
         """Get the country."""
+        country = ''
         dc = self.soup.find("span", {"id": 'country-img'})
-        if not dc:
-            return None
-        return dc.img['title']
+        if dc:
+            country = dc.img['title']
+        return country
 
     def get_genre(self):
         """Get the genre."""
+        genres = []
         dc = self.soup.find("span", {"itemprop": 'genre'})
-        if not dc:
-            return None
-        genres = [i.get_text() for i in dc.find_all("a")]
-        return ', '.join(genres) if genres else None
+        if dc:
+            [genres.append(i.get_text()) for i in dc.find_all("a")]
+        return genres
 
     def get_awards(self):
         """Get the awards.

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,6 +7,7 @@ import random
 import python_filmaffinity
 from python_filmaffinity.config import FIELDS_PAGE_MOVIES, FIELDS_PAGE_DETAIL
 from python_filmaffinity.exceptions import FilmAffinityInvalidLanguage
+import python_filmaffinity.__meta__ as meta_test
 
 path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, path + '/../')
@@ -123,3 +124,9 @@ class TestApi(TestCase):
         self.assertRaises(
             FilmAffinityInvalidLanguage,
             python_filmaffinity.FilmAffinity, lang="abc")
+
+    def test_meta_variables(self):
+        for v in meta_test.__dict__:
+            if v in ['__builtins__', '__package__', '__doc__']:
+                continue
+            self.assertIsNotNone(meta_test.__dict__[v])

--- a/tests/test.py
+++ b/tests/test.py
@@ -20,12 +20,18 @@ class TestApi(TestCase):
         self.assertNotEqual(0, len(movies))
         movie = random.choice(movies)
         for field in FIELDS_PAGE_MOVIES:
-            self.assertNotEqual(movie[field], None)
+            self.assertNotEqual(
+                movie[field], None,
+                msg='Error on getting movie list '
+                    ',field is: {}'.format(field))
         self.assertNotEqual(len(movie['directors']), 0)
 
     def check_element(self, movie):
         for field in FIELDS_PAGE_DETAIL:
-            self.assertNotEqual(movie[field], None)
+            self.assertNotEqual(
+                movie[field], None,
+                msg='Error on checking movie '
+                    'field: {}'.format(field))
 
     def test_search(self):
         movies = self.service.search(title='Batman')
@@ -133,4 +139,6 @@ class TestApi(TestCase):
         for v in meta_test.__dict__:
             if v in ['__builtins__', '__package__', '__doc__']:
                 continue
-            self.assertIsNotNone(meta_test.__dict__[v])
+            self.assertIsNotNone(
+                meta_test.__dict__[v],
+                msg='Error on getting meta value: {}'.format(v))

--- a/tests/test.py
+++ b/tests/test.py
@@ -34,6 +34,9 @@ class TestApi(TestCase):
     def test_get_movie(self):
         movie = self.service.get_movie(id='197671', images=True)
         self.check_element(movie)
+        self.assertNotEqual(
+            movie['images'], [],
+            msg='Error on getting movie images')
 
     def test_top_filmaffinity(self):
         movies = self.service.top_filmaffinity()
@@ -106,10 +109,6 @@ class TestApi(TestCase):
     def test_trailer(self):
         trailer = self.service._get_trailer('Batman')
         self.assertNotEqual(trailer, None)
-
-    def test_images(self):
-        movie = self.service.get_movie(id='668878', images=True)
-        self.assertNotEqual(movie['images'], [])
 
     def test_top_dvd(self):
         movies = self.service.top_dvd(top=10)

--- a/tests/test.py
+++ b/tests/test.py
@@ -38,6 +38,11 @@ class TestApi(TestCase):
             movie['images'], [],
             msg='Error on getting movie images')
 
+    def test_get_movie_by_args(self):
+        movie = self.service.get_movie(
+            title='The Dark Knight')
+        self.check_element(movie)
+
     def test_top_filmaffinity(self):
         movies = self.service.top_filmaffinity()
         self.check_list(movies)


### PR DESCRIPTION
Due to recent changes the coverage decreased considerably (due to my fault, sorry for that)...so...with this pull request I hope that will put things in the right direction, the coverage should be improved considerably and the tests should not fail (crossing fingers).

I think that the next step it could be implement the goodness of the requests-cache module (https://github.com/reclosedev/requests-cache). I don't know if you are familiar with this module, if is not the case: it's similar that the currently implemented cachetools but, in my understanding, the cache is persistent between sessions, because the requests data are stored inside sqlite3 database automatically. It's easy to implement, reduces the server calls and also can be configured, for any single request, to force refresh the data from the server. The bad thing is that we will add another dependency to the project and I honestly don't know if this will conflict with the current cachetools or maybe we could simply switch the cachetools for requests-cache.

What do you thing about that?