### PR TITLE
Some titles have trailing spaces. Lets strip them

### DIFF
--- a/python_filmaffinity/client.py
+++ b/python_filmaffinity/client.py
@@ -181,6 +181,7 @@ class Client:
         return {
             'id': fa_id or page.get_id(),
             'title': page.get_title(),
+            'original_title': page.get_original_title(),
             'year': page.get_year(),
             'duration': page.get_duration(),
             'rating': page.get_rating(),

--- a/python_filmaffinity/pages/detail.py
+++ b/python_filmaffinity/pages/detail.py
@@ -13,6 +13,14 @@ class DetailPage(Page):
             name = name_cell.get_text().strip()
         return name
 
+    def get_original_title(self):
+        """Get the original title."""
+        name = None
+        name_cell = self.soup.find("dl", {"class": 'movie-info'})
+        if name_cell:
+            name = name_cell.find('dd').get_text().strip()
+        return name
+
     def get_year(self):
         """Get the year."""
         year = None

--- a/python_filmaffinity/pages/detail.py
+++ b/python_filmaffinity/pages/detail.py
@@ -10,7 +10,7 @@ class DetailPage(Page):
         name = None
         name_cell = self.soup.find("span", {"itemprop": 'name'})
         if name_cell:
-            name = name_cell.get_text()
+            name = name_cell.get_text().strip()
         return name
 
     def get_year(self):


### PR DESCRIPTION
Could be needed to clean titles in other areas of the code. This is a minimal patch